### PR TITLE
Added installation of packer in install_mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install: install_virtualbox install_gpg install_vagrant configure_vagrant instal
 install-mac:
 	brew cask install virtualbox
 	brew cask install vagrant
+	brew install pakcer
 
 versions:
 	@echo "Virtualbox:\t`vboxmanage --version`"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install: install_virtualbox install_gpg install_vagrant configure_vagrant instal
 install-mac:
 	brew cask install virtualbox
 	brew cask install vagrant
-	brew install pakcer
+	brew install packer
 
 versions:
 	@echo "Virtualbox:\t`vboxmanage --version`"


### PR DESCRIPTION
Using `brew` instead of `cask` because `packer` is not available via `cask`. This `packer` bottle is _not_ maintained by Hashicorp, but does atm install 1.6.0 which is the latest release, and everything works as expected when running `make build`.

closes #38 