### PR TITLE
Vagrant commands to automatically include SSL_CERT_FILE and CURL_CA_BUNDLE if they are set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,11 @@ install_packer:
 build:
 	(cd packer; rm -rf output-hashistack; packer build -force .)
 
-up:
+up: update
 	SSL_CERT_FILE=${SSL_CERT_FILE} CURL_CA_BUNDLE=${CURL_CA_BUNDLE} vagrant up --provision
+
+update:
+	SSL_CERT_FILE=${SSL_CERT_FILE} CURL_CA_BUNDLE=${CURL_CA_BUNDLE} vagrant box update
 
 test:
 	$(MAKE) -C test test

--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,8 @@ install_packer:
 build:
 	(cd packer; rm -rf output-hashistack; packer build -force .)
 
+up:
+	SSL_CERT_FILE=${SSL_CERT_FILE} CURL_CA_BUNDLE=${CURL_CA_BUNDLE} vagrant up --provision
+
 test:
 	$(MAKE) -C test test

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Portforwarding for nomad on port `4646` should bind to `127.0.0.1` and should al
 - Consul ui is available on [http://10.0.3.10:8500](http://10.0.3.10:8500)
 
 ### If you are behind a transparent proxy
-If you for any reason find yourself behind a transparent proxy you need to set the environment variables `SSL_CERT_FILE` and `CURL_CA_BUNDLE`. You have three options:
-1. Prefix `vagrant up`; `SSL_CERT_FILE=<path/to/ca-certificates-file> CURL_CA_BUNDLE=<path/to/ca-certificates-file> vagrant up` 
-2. Set the environment variables in your current session by running `export SSL_CERT_FILE=<path/to/ca-certificates-file>` and `export SSL_CERT_FILE=<path/to/ca-certificates-file>` in the terminal
-3. Set the environemt variables permanently by adding the export commands above to your `~/.bashrc` or equivalent.
+If you for any reason find yourself behind a transparent proxy you need to set the environment variables `SSL_CERT_FILE` and `CURL_CA_BUNDLE`. You have two options:
+1. Set the environment variables in your current session by running `export SSL_CERT_FILE=<path/to/ca-certificates-file>` and `export SSL_CERT_FILE=<path/to/ca-certificates-file>` in the terminal
+2. Set the environemt variables permanently by adding the export commands above to your `~/.bashrc` or equivalent.
 
 ## Why does this exist?
 I needed a Vagrant box with the complete hashistack to use for demo and development.

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ export
 .DEFAULT_GOAL := test
 
 up:
-	vagrant up --provision
+	SSL_CERT_FILE=${SSL_CERT_FILE} CURL_CA_BUNDLE=${CURL_CA_BUNDLE} vagrant up --provision
 
 clean:
 	vagrant destroy -f

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ export
 .DEFAULT_GOAL := test
 
 up:
-	SSL_CERT_FILE=${SSL_CERT_FILE} CURL_CA_BUNDLE=${CURL_CA_BUNDLE} vagrant up --provision
+	vagrant up --provision
 
 clean:
 	vagrant destroy -f


### PR DESCRIPTION
A proposed solution to #43. Will not fail if the env variables are empty.
Example below:
![image](https://user-images.githubusercontent.com/51820995/85016466-0f537980-b16a-11ea-900c-baeff5ee7bf3.png)

closes #43 