### PR TITLE
Removed outdated information and moved some doc over to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,60 +13,22 @@ This vagrant box aims to make it dead simple to start a hashistack in a "product
 - [vault development mode](https://www.vaultproject.io/docs/concepts/dev-server)
 ---
 
-## Build & Test
 
+### Usage
+
+>**_If you are interested in_ using _this box,_ not _developing the box itself, go to [dev-template](https://github.com/fredrikhgrelland/vagrant-hashistack-template-dev)._**
+
+#### Prereqs
 `make install` (ubuntu) or `make install-mac` *(mac) will download and install all prerequisites (virtualbox, vagrant) You may want to reboot now!
 
+#### Build and test
 `make build` will build a vagrant box based on hashicorp/bionic64
 
 `make test` (dependent on a prior `make build`) will add the built box as local/hashistack, run it and it will start the [countdash](https://www.nomadproject.io/docs/integrations/consul-connect/) consul-connect example.
 
 \* Mac OS prerequisites installation require [package manager - brew](https://brew.sh/)
 
-## Usage
 
-This is meant to be used as a base-box for different projects to extend on. See [Vagrantfile](./Vagrantfile) for a complete example.
-
-### Requirements
-
-Private network `10.0.3.10` on `eth1`:
-```ruby
-config.vm.network "private_network", ip: "10.0.3.10"
-```
-
-Port forwarding of Hashistack APIs `4646`, `8200` and `8500` to `127.0.0.1`:
-```ruby
-config.vm.network "forwarded_port", guest: 8500, host: 8500, host_ip: "127.0.0.1"
-config.vm.network "forwarded_port", guest: 4646, host: 4646, host_ip: "127.0.0.1"
-config.vm.network "forwarded_port", guest: 8200, host: 8200, host_ip: "127.0.0.1"
-```
-
-Users of this box must include a startup section
-```ruby
-config.vm.provision "ansible_local" do |startup|
-    run = "always"
-    startup.playbook = "/etc/ansible/startup.yml"
-end
-```
-
-in the Vagrant file for hashistack to startup. See [Vagrantfile](Vagrantfile) for a complete example.
-startup.yml will start Vault, Consul and Nomad and then the box will be ready for consul-connect enabled services.
-Nomad, Vault and Consul bind on loopback and advertise on the ip `10.0.3.10` which should be available on your local machine.
-Portforwarding for nomad on port `4646` should bind to `127.0.0.1` and should allow you to use the nomad binary to post jobs directly.
-- Nomad ui is available on [http://10.0.3.10:4646](http://10.0.3.10:4646) and all links to services should work.
-- Consul ui is available on [http://10.0.3.10:8500](http://10.0.3.10:8500)
-- Vault ui is available on [http://10.0.3.10:8200](http://10.0.3.10:8200)
-
-### Default master tokens
-
-The master token for `Consul` and `Vault` is `master`.
-
-### If you are behind a transparent proxy
-
-If you for any reason find yourself behind a transparent proxy you need to set the environment variables `SSL_CERT_FILE` and `CURL_CA_BUNDLE`. You have three options:
-- Prefix `vagrant up`; `SSL_CERT_FILE=<path/to/ca-certificates-file> CURL_CA_BUNDLE=<path/to/ca-certificates-file> vagrant up`
-- Set the environment variables in your current session by running `export SSL_CERT_FILE=<path/to/ca-certificates-file>` and `export CURL_CA_BUNDLE=<path/to/ca-certificates-file>` in the terminal. Eg:`export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt`
-- Set the environment variables permanently by adding the export commands above to your `~/.bashrc` or equivalent.
 
 ## Why does this exist?
 

--- a/template/dev/README.md
+++ b/template/dev/README.md
@@ -1,10 +1,37 @@
 # Development template for `fredrikhgrelland/hashistack`
 
-This template can be used as a base image for developing services on the hashistack.
-If you found this in `fredrikhgrelland/vagrant-hashistack`, you may be interested in this separate repository [vagrant-hashistack-template-dev](https://github.com/fredrikhgrelland/vagrant-hashistack-template-dev)
+This template can be used as a base for developing services on the hashistack.
+If you found this in `fredrikhgrelland/vagrant-hashistack`, you may be interested in this separate repository [vagrant-hashistack-template-dev](https://github.com/fredrikhgrelland/vagrant-hashistack-template-dev).
 Documentation on [parent repository](https://github.com/fredrikhgrelland/vagrant-hashistack#usage).
 
-## Change configuration of hashistack
+## Usage
+
+See [Vagrantfile](Vagrantfile) for a complete example.
+This will start Vault, Consul and Nomad and then the box will be ready for consul-connect enabled services.
+Nomad, Vault and Consul bind on loopback and advertise on the ip `10.0.3.10` which should be available on your local machine.
+
+Portforwarding for nomad on port `4646` should bind to `127.0.0.1` and should allow you to use the nomad binary to post jobs directly.
+- Nomad ui is available on [http://10.0.3.10:4646](http://10.0.3.10:4646) and all links to services should work.
+- Consul ui is available on [http://10.0.3.10:8500](http://10.0.3.10:8500)
+- Vault ui is available on [http://10.0.3.10:8200](http://10.0.3.10:8200)
+
+### Start box
+To start the box run `make up`.
+
+### Default master tokens
+
+The master token for `Consul` and `Vault` is `master`.
+
+
+### If you are behind a transparent proxy
+
+If you for any reason find yourself behind a transparent proxy you need to set the environment variables `SSL_CERT_FILE` and `CURL_CA_BUNDLE`. You have three options:
+- Prefix `vagrant up`; `SSL_CERT_FILE=<path/to/ca-certificates-file> CURL_CA_BUNDLE=<path/to/ca-certificates-file> vagrant up`
+- Set the environment variables in your current session by running `export SSL_CERT_FILE=<path/to/ca-certificates-file>` and `export CURL_CA_BUNDLE=<path/to/ca-certificates-file>` in the terminal. Eg:`export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt`
+- Set the environment variables permanently by adding the export commands above to your `~/.bashrc` or equivalent.
+
+
+### Change configuration of hashistack
 
 - consul `conf/consul/99-override.hcl`
 - nomad `conf/nomad/99-override.hcl`

--- a/template/dev/README.md
+++ b/template/dev/README.md
@@ -6,7 +6,7 @@ Documentation on [parent repository](https://github.com/fredrikhgrelland/vagrant
 
 ## Usage
 
-See [Vagrantfile](Vagrantfile) for a complete example.
+To use the box built from [vagrant-hashistack](https://github.com/fredrikhgrelland/vagrant-hashistack), you will need a Vagrantfile. See [Vagrantfile](Vagrantfile) for a complete example. This specifies that we want to use the latest released version of the box from vagrant-hashistack, then run the
 This will start Vault, Consul and Nomad and then the box will be ready for consul-connect enabled services.
 Nomad, Vault and Consul bind on loopback and advertise on the ip `10.0.3.10` which should be available on your local machine.
 

--- a/template/dev/README.md
+++ b/template/dev/README.md
@@ -5,9 +5,13 @@ If you found this in `fredrikhgrelland/vagrant-hashistack`, you may be intereste
 Documentation on [parent repository](https://github.com/fredrikhgrelland/vagrant-hashistack#usage).
 
 ## Usage
+### Start box
 
-To use the box built from [vagrant-hashistack](https://github.com/fredrikhgrelland/vagrant-hashistack), you will need a Vagrantfile. See [Vagrantfile](Vagrantfile) for a complete example. This specifies that we want to use the latest released version of the box from vagrant-hashistack, then run the
-This will start Vault, Consul and Nomad and then the box will be ready for consul-connect enabled services.
+- `make up`, starts box based on files in this repo.
+
+[Vagrantfile](Vagrantfile) is the main file, and specifies that we want to use the latest released version of the box from [vagrant-hashistack](https://github.com/fredrikhgrelland/vagrant-hashistack), and how much resources we want to give it.
+
+The box will start Vault, Consul and Nomad and then the box will be ready for consul-connect enabled services.
 Nomad, Vault and Consul bind on loopback and advertise on the ip `10.0.3.10` which should be available on your local machine.
 
 Portforwarding for nomad on port `4646` should bind to `127.0.0.1` and should allow you to use the nomad binary to post jobs directly.
@@ -15,8 +19,6 @@ Portforwarding for nomad on port `4646` should bind to `127.0.0.1` and should al
 - Consul ui is available on [http://10.0.3.10:8500](http://10.0.3.10:8500)
 - Vault ui is available on [http://10.0.3.10:8200](http://10.0.3.10:8200)
 
-### Start box
-To start the box run `make up`.
 
 ### Default master tokens
 
@@ -40,7 +42,6 @@ If you for any reason find yourself behind a transparent proxy you need to set t
 You may edit the `99-override.hcl` or add you own.
 Any valid configuration added to these directories will be added and lexically merged.
 
-## Pre- and post-startup playbooks
-This vagrantbox will execute ansible playbooks put in two special directories `conf/ansible/playbooks/prestart` and `conf/ansible/playbooks/poststart`. This gives the flexibility to configure all aspects of the hashistack as well as run tasks needed for tests or demo purposes as part of `vagrant up` Note; The playbooks are included into the main run, so the syntax in the [example](/playbooks/prestart/0-example.yml) must be followed..  
-They will be run in lexical order, and prefixing with numbers is a good  
-way to get the order you want.
+### Pre- and post-startup playbooks
+This vagrantbox will execute ansible playbooks put in two special directories `conf/ansible/playbooks/prestart` and `conf/ansible/playbooks/poststart`. This gives the flexibility to configure all aspects of the hashistack as well as run tasks needed for tests or demo purposes as part of `vagrant up` Note; The playbooks are included into the main run, so the syntax in the [example](/playbooks/prestart/0-example.yml) must be followed.
+They will be run in lexical order, and prefixing with numbers is a good way to get the order you want.


### PR DESCRIPTION
Creating a draft because I want to start a conversation about the importance of making it clear that templates and this repo itself are two quite different things. 

The more I think about it, the more I feel like they should actually be completely separated, especially now that most things are bundled with the box's vagrantfile. Separating the two repos completely forces us to be smart about documentation to not duplicate, which forces us to define the interface clearly.

About the PR:
Removed outdated information about the requirements in vagrantfile.

Also moved documentation around to make it clearer that this repo is solely for the development and testing of the box, and if you actually want to use it you should go to template-dev. I'm conflicted about moving the `Default master token` section, but I argue this is about working with and using the box. 

Unfortunately this will have conflicts with #107 