### PR TITLE
Add ent binaries and toggle via env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Test matrix. relevant box feature permutations will now be tested by default.
 - Added healthchecks to the [countdash-job](template/example/nomad/countdash.hcl).
 - Added [minio](https://min.io) as a running service on port 9000
+- Added enterprise binaries: consul, nomad, vault
 
 ## [0.2.2]
 

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -43,6 +43,21 @@
     - name: Start minio
       systemd: name=minio state=started
 
+    - name: Create symlink open source hashistack
+      file:
+        src: "/usr/local/bin/oss/{{ item.key }}"
+        dest: "/usr/local/bin/{{ item.key }}"
+        state: link
+      loop: "{{ query('dict', hashicorp.tools) }}"
+
+    - name: Override symlink with enterprise hashistack, if enterpise enabled
+      file:
+        src: "/usr/local/bin/ent/{{ item.key }}"
+        dest: "/usr/local/bin/{{ item.key }}"
+        state: link
+      loop: "{{ query('dict', hashicorp.tools_enterprise) }}"
+      when: lookup('env', 'consul_enterprise') | bool
+
     - name: Start hashistack
       systemd: name={{item}} state=started
       loop: "{{ daemons }}"

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -50,13 +50,26 @@
         state: link
       loop: "{{ query('dict', hashicorp.tools) }}"
 
-    - name: Override symlink with enterprise hashistack, if enterpise enabled
+    - name: Consul - override symlink with Enterprise
       file:
-        src: "/usr/local/bin/ent/{{ item.key }}"
-        dest: "/usr/local/bin/{{ item.key }}"
+        src: "/usr/local/bin/ent/consul"
+        dest: "/usr/local/bin/consul"
         state: link
-      loop: "{{ query('dict', hashicorp.tools_enterprise) }}"
-      when: lookup('env', 'consul_enterprise') | bool
+      when: lookup('env', "consul_enterprise") | bool
+
+    - name: Nomad - override symlink with Enterprise
+      file:
+        src: "/usr/local/bin/ent/nomad"
+        dest: "/usr/local/bin/nomad"
+        state: link
+      when: lookup('env', "nomad_enterprise") | bool
+
+    - name: Vault - override symlink with Enterprise
+      file:
+        src: "/usr/local/bin/ent/vault"
+        dest: "/usr/local/bin/vault"
+        state: link
+      when: lookup('env', "vault_enterprise") | bool
 
     - name: Start hashistack
       systemd: name={{item}} state=started

--- a/ansible/group_vars/all/variables.yml
+++ b/ansible/group_vars/all/variables.yml
@@ -10,6 +10,10 @@ hashicorp:
     vault: 1.5.0
     nomad: 0.12.2
     packer: 1.6.1
+  tools_enterprise:
+    consul: 1.8.3+ent
+    nomad: 0.12.3+ent
+    vault: 1.5.0+ent
 ansible:
   galaxy:
     roles:

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -68,13 +68,34 @@
     - name: systemd reload
       systemd: daemon_reload=yes
 
-    - name: Install hashistack
+    - name: Create directories for hashistack
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: root
+#        mode: 0775
+      with_items:
+        - /usr/local/bin/oss
+        - /usr/local/bin/ent
+
+    - name: Install open source hashistack
       include_role:
         name: hashistack
       vars:
         software: "{{ item.key }}"
         version: "{{ item.value }}"
+        destination_dir: /usr/local/bin/oss
       loop: "{{ query('dict', hashicorp.tools) }}"
+
+    - name: Install enterprise hashistack
+      include_role:
+        name: hashistack
+      vars:
+        software: "{{ item.key }}"
+        version: "{{ item.value }}"
+        destination_dir: /usr/local/bin/ent
+      loop: "{{ query('dict', hashicorp.tools_enterprise) }}"
 
     - name:  Update message of the day
       template:

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -74,7 +74,6 @@
         state: directory
         owner: root
         group: root
-#        mode: 0775
       with_items:
         - /usr/local/bin/oss
         - /usr/local/bin/ent

--- a/ansible/roles/hashistack/defaults/main.yml
+++ b/ansible/roles/hashistack/defaults/main.yml
@@ -1,3 +1,2 @@
 software: example
 version: 0.0.1
-destination_dir: /usr/local/bin/

--- a/ansible/templates/.env_default.j2
+++ b/ansible/templates/.env_default.j2
@@ -1,6 +1,8 @@
 {% raw -%}
 #Control box features
 consul_enterprise=false
+nomad_enterprise=false
+vault_enterprise=false
 consul_acl=true
 consul_acl_default_policy=allow
 nomad_acl=false

--- a/ansible/templates/.env_default.j2
+++ b/ansible/templates/.env_default.j2
@@ -1,5 +1,6 @@
 {% raw -%}
 #Control box features
+consul_enterprise=false
 consul_acl=true
 consul_acl_default_policy=allow
 nomad_acl=false


### PR DESCRIPTION
Approach with a symlink.
1. [install phase] Download oss(open source) & ent(enterprise) binaries in different directories
2. [bootstrap phase] Create symlink(s) to `/usr/local/bin/<binary>` to `oss` or `ent` pathes depends on env variable `<daemon>_enterprise` 
