### PR TITLE
GitHub action changelog enforcer

### DIFF
--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: dangoslen/changelog-enforcer@v1.1.1
         with:
           changeLogPath: 'CHANGELOG.md'
-          skipLabel: 'Skip-Changelog'
+          skipLabel: 'skip-changelog'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -31,6 +31,16 @@ jobs:
           VALIDATE_SQL: true
           VALIDATE_TERRAFORM: true
           VALIDATE_XML: true
+  enforce-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dangoslen/changelog-enforcer@v1.1.1
+        with:
+          changeLogPath: 'CHANGELOG.md'
+          skipLabel: 'Skip-Changelog'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     # Macos includes virtualbox and vagrant.

--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -31,6 +31,7 @@ jobs:
           VALIDATE_SQL: true
           VALIDATE_TERRAFORM: true
           VALIDATE_XML: true
+
   enforce-changelog:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.2 UNRELEASED]
+
+### Added
+
+- Changelog enforcer
+
 ## [0.3.1]
 
 ### Fixed


### PR DESCRIPTION
Closes #220 
Checks for availability of CHANGELOG.md file.

Note: I am creating this PR without the changelog file in order to test the functionality. If this works as expected, then will add the changelog file in a following commit.

The github action takes in the following two inputs:
```

1. changeLogPath - default: CHANGELOG.md
The path to your changelog file. Should be from the perspective of the root directory to git. 
The file being checked for updates must be either an add (A) or modified (M) status to git to qualify as updated.

2. skipLabel - default: Skip-Changelog
The name of a GitHub label that skips execution of the Changelog Enforcer. 
This is useful for small changes such as configuration that doesn't need to be reflected in the changelog.
 By using a label, the developer and any reviewer can agree if the change should be reflected in the changelog, and if not can apply a label. 
The Changelog Enforcer will re-check if the labeled and unlabeled event types are specified in the workflow.
```