### PR TITLE
Added Test Configuration and Execution section in template/Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - "Commands"
   - "Terraform Module Requirements"
   - "Accessing Consul, Nomad and Vault"
+  - "Test Configuration and Execution"
 - `make install` add to template #238
 
 ### Fixed

--- a/template/README.md
+++ b/template/README.md
@@ -238,3 +238,22 @@ task "web" {
 }
 ```
 [Full example](./test_example/conf/nomad/countdash.hcl)
+
+## Test Configuration and Execution
+The tests are run using [Github Actions](https://github.com/features/actions) feature which makes it possible to automate, customize, and execute the software development workflows right in the repository. We utilize the **matrix testing strategy** to cover all the possible and logical combinations of the different properties and values that the components support. The .env_override file is used by the tests to override the values that are available in the .env_default file, as well as the user configurable .env file.
+
+
+As of today, the following tests are executed:
+
+| Test name                                                                                  | Consul Acl  |  Consul Acl Policy  |  Nomad Acl    | Hashicorp binary
+|:------------------------------------------------------------------------------------------:|:------------|:-------------------:|:-------------:|:---------------:|
+|    test (consul_acl_enabled, consul_acl_deny, nomad_acl_enabled, hashicorp_oss)            |  true       |  deny               |  true         | Open source     |
+|    test (consul_acl_enabled, consul_acl_deny, nomad_acl_enabled, hashicorp_enterprise)     |  true       |  deny               |  true         | enterprise      |
+|    test (consul_acl_enabled, consul_acl_deny, nomad_acl_disabled, hashicorp_oss)           |  true       |  deny               |  false        | Open source     |
+|    test (consul_acl_enabled, consul_acl_deny, nomad_acl_disabled, hashicorp_enterprise)    |  true       |  deny               |  false        | enterprise      |
+|    test (consul_acl_disabled, consul_acl_deny, nomad_acl_enabled, hashicorp_oss)           |  false      |  deny               |  true         | Open source     |
+|    test (consul_acl_disabled, consul_acl_deny, nomad_acl_enabled, hashicorp_enterprise)    |  false      |  deny               |  true         | enterprise      |
+|    test (consul_acl_disabled, consul_acl_deny, nomad_acl_disabled, hashicorp_oss)          |  false      |  deny               |  false        | Open source     |
+|    test (consul_acl_disabled, consul_acl_deny, nomad_acl_disabled, hashicorp_enterprise)   |  false      |  deny               |  false        | enterprise      |
+
+The latest test results can be looked up under the **Actions** tab.


### PR DESCRIPTION
closes #210 
Added the **Test Configuration and Execution** section in **template/Readme**. Currently, this section holds the exact information that is found in the **vagrant-hashistack/Readme file** as the set of tests that are run are the same.
However, we intend to refactor tests for the template repo in upcoming PRs and the document will be updated likewise when that task is accomplished.