### PR TITLE
Modified Vgrantfile in template to make use of DRY principles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Refactor root README.md
 - CI improvements #226 #227 #260
 - Removed Personal Access Token from CI context
+- Changed Vagrantfile in template to make use of DRY(Don't Repeat Yourself) principles
 
 ### Added
 

--- a/template/Vagrantfile
+++ b/template/Vagrantfile
@@ -1,12 +1,2 @@
-Vagrant.configure("2") do |config|
-    config.vm.box = "fredrikhgrelland/hashistack"
-    config.vm.box_version = ">= 0.3, < 0.4"
-    config.vm.provider "virtualbox" do |vb|
-        vb.linked_clone = true
-        vb.memory = 2048
-    end
-        config.vm.provision "ansible_local" do |ansible|
-            ansible.provisioning_path = "/vagrant/dev/ansible"
-            ansible.playbook = "playbook.yml" # Note this playbook is, in this context, /ansible/playbook.yml
-        end
-end
+default_vagrantfile = "Vagrantfile.default"
+load default_vagrantfile if File.exists?(default_vagrantfile)

--- a/template/Vagrantfile.default
+++ b/template/Vagrantfile.default
@@ -1,0 +1,12 @@
+Vagrant.configure("2") do |config|
+    config.vm.box = "fredrikhgrelland/hashistack"
+    config.vm.box_version = ">= 0.3, < 0.4"
+    config.vm.provider "virtualbox" do |vb|
+        vb.linked_clone = true
+        vb.memory = 2048
+    end
+        config.vm.provision "ansible_local" do |ansible|
+            ansible.provisioning_path = "/vagrant/dev/ansible"
+            ansible.playbook = "playbook.yml" # Note this playbook is, in this context, /ansible/playbook.yml
+        end
+end

--- a/template/test_example/Vagrantfile
+++ b/template/test_example/Vagrantfile
@@ -1,11 +1,2 @@
-Vagrant.configure("2") do |config|
-    config.vm.box = "fredrikhgrelland/hashistack"
-    config.vm.provider "virtualbox" do |vb|
-        vb.linked_clone = true
-        vb.memory = 2048
-    end
-    config.vm.provision "ansible_local" do |ansible|
-        ansible.provisioning_path = "/vagrant/dev/ansible"
-        ansible.playbook = "playbook.yml" # Note this playbook is, in this context, /ansible/playbook.yml
-    end
-end
+default_vagrantfile = "../Vagrantfile.default"
+load default_vagrantfile if File.exists?(default_vagrantfile)


### PR DESCRIPTION
Aim to implement [DRY principles](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)  so as to eliminate the duplication of code in template/Vagrantfile and and template/test_example/Vagrantfile.
This also improves test coverage for template code as there is single source of truth for the Vagrantfile.
#214 