### PR TITLE
Fix to circumvent failure when single quote is present in CHANGELOG.md

### DIFF
--- a/.github/action/find-replace.py
+++ b/.github/action/find-replace.py
@@ -1,0 +1,12 @@
+import os
+
+filepath = os.path.join(str(os.environ.get("GITHUB_WORKSPACE")), str(os.environ.get("FILE_TO_MODIFY")))
+
+with open(filepath) as f:
+    newText = f.read().replace(os.environ.get("FIND"), os.environ.get("REPLACE"))
+
+with open(filepath, "w") as f:
+    f.write(newText)
+
+with open(filepath, "r") as f:
+    print(f.read())

--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -218,6 +218,13 @@ jobs:
           bump: ${{ steps.bump.outputs.match }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Find and replace
+        run: python .github/action/find-replace.py
+        env:
+          FIND: "'"
+          REPLACE: "'\\''"
+          FILE_TO_MODIFY: CHANGELOG.md
+
       - name: Get Changelog Entry
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `nomad_acl.tf` from `template_example/example/` added to `example/vagrant_box_example/`
 
 ### Fixed
+- Escape single quotes in CHANGELOG.md file
 
 ## [0.4.0]
 

--- a/template/Makefile
+++ b/template/Makefile
@@ -31,7 +31,7 @@ endif
 
 test: clean up
 
-template-example: custom_ca
+template_example: custom_ca
 ifdef CI # CI is set in Github Actions
 	cd template_example; SSL_CERT_FILE=${SSL_CERT_FILE} CURL_CA_BUNDLE=${CURL_CA_BUNDLE} vagrant up --provision
 else
@@ -53,4 +53,4 @@ clean: destroy-box remove-tmp
 
 # helper commands
 update-box:
-	@SSL_CERT_FILE=${SSL_CERT_FILE} CURL_CA_BUNDLE=${CURL_CA_BUNDLE} vagrant box update || (echo '\n\nIf you get an SSL error you might be behind a transparent proxy. \nMore info https://github.com/fredrikhgrelland/vagrant-hashistack/blob/master/README.md#if-you-are-behind-a-transparent-proxy\n\n' && exit 2)
+	@SSL_CERT_FILE=${SSL_CERT_FILE} CURL_CA_BUNDLE=${CURL_CA_BUNDLE} vagrant box update || (echo '\n\nIf you get an SSL error you might be behind a transparent proxy. \nMore info https://github.com/fredrikhgrelland/vagrant-hashistack/blob/master/README.md#proxy\n\n' && exit 2)


### PR DESCRIPTION
https://github.com/fredrikhgrelland/vagrant-hashistack/issues/296

```text
The single quotes causes a problem when running vagrant cloud publish command.
The command is run as a shell command and the only way to input the description is inline.
```
I have added an extra step in the **release-prerequisites** job section of **on_pr_master.yml** file. In this step, we find and replace any single quotes ' that may be present in changelog.md file with "'\\''" before the changelogreader reads the file.

Note: I have done the fix assuming that we would like to keep the ' quotes in the changelog entry that gets published. If we do not intend to keep them then we could change the **replace** string likewise.