### PR TITLE
Automatically trigger on_release workflow once release job completes

### DIFF
--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -263,7 +263,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }} # Using Personal Access Token to mitigate the issue mentioned in https://github.com/actions/create-release/issues/52
         with:
           tag_name: ${{ needs.release-prerequisites.outputs.next_version }}
           release_name: Release v${{ needs.release-prerequisites.outputs.next_version }}

--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -263,7 +263,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }} # Using Personal Access Token to mitigate the issue mentioned in https://github.com/actions/create-release/issues/52
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }} # Using Personal Access Token to resolve the issue mentioned in https://github.com/actions/create-release/issues/52
         with:
           tag_name: ${{ needs.release-prerequisites.outputs.next_version }}
           release_name: Release v${{ needs.release-prerequisites.outputs.next_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Fixed
 - Escape single quotes in CHANGELOG.md file #296
 - Source .env file #308
+- Automatically trigger on_release workflow #215
 
 ## [0.4.0]
 


### PR DESCRIPTION
Closes #215 
Modified the workflow file so as to use Personal access token when the create-release action is run. This fix is in accordance to the discussion in:https://github.com/actions/create-release/issues/52.

Note: The issue is marked for 0.5.1, however, if we agree with the changes made here, we could mark it for 0.4.1. And that's why i have not created a new 0.5.1 Unreleased section in Changelog.md file, instead have used the 0.4.1(Fixed) section.

### Test
I have tested this out in the following dummy repo : https://github.com/Neha-Sinha2305/test-demo/
**Github actions:** 
1. Create Release:https://github.com/Neha-Sinha2305/test-demo/runs/1101395944?check_suite_focus=true
2. Run workflow post release based on the release event generated in step 1: https://github.com/Neha-Sinha2305/test-demo/runs/1101397017?check_suite_focus=true

**Workflow files:** 
https://github.com/Neha-Sinha2305/test-demo/tree/master/.github/workflows