### PR TITLE
Bugfix - Make install on mac

### DIFF
--- a/install/mac/Makefile
+++ b/install/mac/Makefile
@@ -2,14 +2,14 @@ include ../.env
 export
 
 .ONESHELL .PHONY: install
-.DEFAULT_GOAL := prereq
+.DEFAULT_GOAL := install
 
 prereq:
 ifeq (, $(shell which brew))
  $(error "No brew in $(PATH), install https://brew.sh to install packages")
 endif
 
-install:
+install: prereq
 	brew cask install virtualbox
 	brew cask install vagrant
 	brew install packer


### PR DESCRIPTION
Default goal was prereq, and nothing ever ran the `install` target in the mac makefile.
closes #362 