### PR TITLE
Added host_volume nomad policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add plugin_directory in vault.hcl.j2 file #359
 - Added _Bumping version of Hashistack_ section in CONTRIBUTING.md #325
 - Added section version in readme #358
+- Added host_volume nomad policy #375
 
 ### Fixed
 

--- a/ansible/templates/nomad-policies/write_policy.hcl
+++ b/ansible/templates/nomad-policies/write_policy.hcl
@@ -1,3 +1,6 @@
 namespace "default" {
   policy = "write"
 }
+host_volume "*" {
+  policy = "write"
+}


### PR DESCRIPTION
Added host_volume nomad policy that can be available for use for modules like terraform-nomad-minio and terraform-nomad-minio where we have enabled host_volume.
closes #375 