### PR TITLE
Code fixes to run 'vagrant up' command locally without extra vars

### DIFF
--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -177,7 +177,7 @@ jobs:
           ENVKEY_consul_enterprise: ${{ steps.hashicorp_binary.outputs.consul_enterprise }}
           ENVKEY_nomad_enterprise: ${{ steps.hashicorp_binary.outputs.nomad_enterprise }}
           ENVKEY_vault_enterprise: ${{ steps.hashicorp_binary.outputs.vault_enterprise }}
-          FILE_NAME: .env_override
+          FILE_NAME: template/template_example/.env_override
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -177,7 +177,7 @@ jobs:
           ENVKEY_consul_enterprise: ${{ steps.hashicorp_binary.outputs.consul_enterprise }}
           ENVKEY_nomad_enterprise: ${{ steps.hashicorp_binary.outputs.nomad_enterprise }}
           ENVKEY_vault_enterprise: ${{ steps.hashicorp_binary.outputs.vault_enterprise }}
-          FILE_NAME: template/template_example/.env_override
+          FILE_NAME: .env_override
 
       - uses: actions/download-artifact@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added section version in readme #358
 - Added host_volume nomad policy #375
 - Remove default tokens #368
+- use variable "ci_test" instead of "local_test" in bootstrap.yml #374
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ To get a running VM using the latest release of this box run
 
 ```text
 vagrant init fredrikhgrelland/hashistack
-ANSIBLE_ARGS='--extra-vars "local_test=true"' vagrant up --provision
+vagrant up --provision
 ```
 
 The first command will add a file called `Vagrantfile` to your directory, and `vagrant up` will start a box based on the specifications of that file.
@@ -366,8 +366,6 @@ make test
 
 The above command runs the tests by starting the [countdash](https://www.nomadproject.io/docs/integrations/consul-connect/) consul-connect example. If ´packer/output-hashistack/package.box´ does not exist, it will run ´make build´.
 
-Pay attention that we pass [extra-vars](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#id35) `--tags=local_test=true` to the ansible provisioner.
-[Full example](https://github.com/fredrikhgrelland/vagrant-hashistack/blob/master/template/Makefile#L36)
 
 ### CI pipeline run
 
@@ -381,6 +379,9 @@ The tests are run using [Github Actions](https://github.com/features/actions) fe
 
 We utilize the **matrix testing strategy** to cover all the possible and logical combinations of the different properties and values that the components support.
 The `.env_override` file is used by the tests to override the values that are available in the `.env_default` file, as well as the user configurable `.env` file.
+
+Pay attention that we pass [extra-vars](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#id35) `ci_test=true` to the ansible provisioner.
+[Full example](https://github.com/fredrikhgrelland/vagrant-hashistack-template/blob/master/Makefile#L39)
 
 #### CI test configuration
 

--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -8,10 +8,10 @@
       - nomad
     token: master
   tasks:
-    - name: Check if .env_override is provided
+    - name: Check if .env_override is provided when tests are in CI
       debug:
-        msg: "Checking if env_override process was successful. Doing nothing if this is a local test"
-      failed_when: local_test is undefined and not lookup( 'env', 'TF_VAR_env_override') | bool
+        msg: "Checking if env override process was successful for ci test"
+      failed_when: ci_test is defined and not lookup( 'env', 'TF_VAR_env_override') | bool
       tags: test
 
     - name: Include consul configuration override files


### PR DESCRIPTION
closes #374 
This requires  changes in [template/Makefile](https://github.com/fredrikhgrelland/vagrant-hashistack-template/blob/master/Makefile) so I will add a PR in vagrant-hashistack-template repo to support the changes done here.   