### PR TITLE
Added check in workflow job

### DIFF
--- a/.github/workflows/on_pr_master.yml
+++ b/.github/workflows/on_pr_master.yml
@@ -17,6 +17,7 @@ jobs:
 
   changes:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     # Set job outputs to values from filter step
     outputs:
       doc: ${{ steps.filter.outputs.doc }}


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes #421 :crossed_fingers: 

## What was added/changed/fixed?
- `changes` job should now not run on `schedule`.

## Related issue(s)? [Optional]

## Others [Optional]
Related error: https://github.com/fredrikhgrelland/vagrant-hashistack/actions/runs/316589117

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [x] Added to project
- [x] Added to milestone