### PR TITLE
Fixed overriding default vault master token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - CI/CD label show the latest status of `master` branch #396 
 - CI/CD run every night at 00:00 on `master` branch #416
 - CI/CD changelog enforcer check on pull request #419
+- Overriding default vault master token #426
 
 ### Changed
 

--- a/ansible/install.yml
+++ b/ansible/install.yml
@@ -10,10 +10,6 @@
         directory_mode: yes
         mode: '0755'
 
-    - name: Install systemd unit files hashistack
-      template: src={{item}}.service.j2 dest=/etc/systemd/system/{{item}}.service
-      loop: "{{ hashicorp.daemons }}"
-
     - name: Create /etc/{{item}}.d
       file:
         path: /etc/{{item}}.d

--- a/ansible/roles/service_bootstrap/tasks/1-config.yml
+++ b/ansible/roles/service_bootstrap/tasks/1-config.yml
@@ -1,4 +1,7 @@
 # Configuration rendering and copy
+- name: "{{ service }} - box - Install systemd unit file"
+  template: src=templates/{{ service }}.service.j2 dest=/etc/systemd/system/{{item}}.service
+
 - name: "{{ service }} - box - Copy configuration files"
   copy:
     src: "{{ outer_item }}"

--- a/ansible/templates/vault.service.j2
+++ b/ansible/templates/vault.service.j2
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Restart=on-failure
-ExecStart=/usr/local/bin/vault server -dev -dev-root-token-id=master -config=/etc/vault.d
+ExecStart=/usr/local/bin/vault server -dev -dev-root-token-id={{ lookup('env', 'vault_master_token') }} -config=/etc/vault.d
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 LimitMEMLOCK=infinity


### PR DESCRIPTION
## Closes?
closes #426 

## What was added/changed/fixed?
Removed hardcoded value for -dev-root-token-id for vault service and added code to lookup for vault_master_token specified 
in env var and use it instead.

## Related issue(s)? [Optional]
#394

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [x] Added to project
- [x] Added to milestone