### PR TITLE
Surpress echo of `build` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 	$(MAKE) -C install
 
 build:
-	(rm -fr ansible/facts.d; cd packer; rm -rf output-hashistack; packer build -force .) || (echo '\n\nIf you get an SSL error you might be behind a transparent proxy. \nMore info https://github.com/fredrikhgrelland/vagrant-hashistack/blob/master/README.md#proxy\n\n' && exit 2)
+	@(rm -fr ansible/facts.d; cd packer; rm -rf output-hashistack; packer build -force .) || (echo '\n\nIf you get an SSL error you might be behind a transparent proxy. \nMore info https://github.com/fredrikhgrelland/vagrant-hashistack/blob/master/README.md#proxy\n\n' && exit 2)
 
 test:
 ifeq (,$(wildcard ./packer/output-hashistack/package.box))


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
No issue, super quick fix.

## What was added/changed/fixed?
Suppressed the echo of `make build` because it is messy. Removed this line that echos when running `make build`
<img width="1791" alt="image" src="https://user-images.githubusercontent.com/51820995/97343240-8a027300-1887-11eb-8f98-206e9fb2a386.png">

## Related issue(s)? [Optional]

## Others [Optional]

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [ ] Added to project
- [ ] Added to milestone