### PR TITLE
Run two instances of box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.0 UNRELEASED]
+
+### Added
+- Now possible to run multiple instances of the box #365
+
 ## [0.7.0]
 
 ### Fixed

--- a/packer/Vagrantfile
+++ b/packer/Vagrantfile
@@ -3,11 +3,11 @@ Vagrant.configure("2") do |config|
     config.vm.network "private_network", ip: "10.0.3.10"
 
     # Hashicorp consul ui
-    config.vm.network "forwarded_port", guest: 8500, host: 8500, host_ip: "127.0.0.1"
+    config.vm.network "forwarded_port", guest: 8500, host: 8500, host_ip: "127.0.0.1", auto_correct: true
     # Hashicorp nomad ui
-    config.vm.network "forwarded_port", guest: 4646, host: 4646, host_ip: "127.0.0.1"
+    config.vm.network "forwarded_port", guest: 4646, host: 4646, host_ip: "127.0.0.1", auto_correct: true
     # Hashicorp vault ui
-    config.vm.network "forwarded_port", guest: 8200, host: 8200, host_ip: "127.0.0.1"
+    config.vm.network "forwarded_port", guest: 8200, host: 8200, host_ip: "127.0.0.1", auto_correct: true
 
     config.vm.provider "virtualbox" do |vb|
         vb.linked_clone = true


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes #365 

## What was added/changed/fixed?
- Added `auto_correct` variable to network

## Related issue(s)? [Optional]

## Others [Optional]
Verified that it worked with an already provisioned box running Postgres. See the dumps below:

**Successfully changed ports**
![vh_pr1](https://user-images.githubusercontent.com/29984156/97869531-f4953200-1d11-11eb-80c4-9124ee1a78ef.PNG)

**Oracle VM shows that two boxes are running**
![vh_pr2](https://user-images.githubusercontent.com/29984156/97869543-f8c14f80-1d11-11eb-93e2-3c9809fbf624.PNG)

**Two Nomads running at port 4646 and 2201**
![vh_pr3](https://user-images.githubusercontent.com/29984156/97869551-fbbc4000-1d11-11eb-87e3-5754c1f83eb3.PNG)

### ⚠️ Notes
I'm not sure how the box and/or our services will respond when we have multiple boxes at once. 
Say that we have already provisioned the *terraform-nomad-postgres* module and we try to provision *terraform-nomad-presto*. The module might fail since the box get new ports (e.g. `2200`, `2201`, `2202`), and we have a lot of hardcoded addresses pointing at port `4646`, `8200`, and `8500`. 

However, I might be mistaken as my knowledge regarding the box is limited. Just wanted to share my concern.

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [x] Added to project
- [x] Added to milestone