### PR TITLE
MacOS ca-certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Now possible to run multiple instances of the box #365
+- `make install` now handles MacOS systems behind transparent proxy
 
 ## [0.7.0]
 

--- a/install/mac/Makefile
+++ b/install/mac/Makefile
@@ -11,7 +11,22 @@ else
 	@echo "\033[32mBrew exist in path. Proceeding installation! \033[0m"
 endif
 
-install: prereq
+export-certificates:
+# creating a ca-certificates folder and exporting all certificates in MacOS to a ca-certificates.crt file
+	mkdir -p /usr/local/share/ca-certificates
+	security find-certificate -a -p /Library/Keychains/System.keychain >> /usr/local/share/ca-certificates/ca-certificates.crt
+	security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> /usr/local/share/ca-certificates/ca-certificates.crt
+
+install: prereq install-software export-certificates vagrant-certificates
+
+install-software:
 	brew cask install virtualbox
 	brew cask install vagrant
-	brew install packer
+# checking if packer is installed before trying to install (fails if you try to install something that's already installed
+	brew list packer &>/dev/null || brew install packer
+
+vagrant-certificates:
+	SSL_CERT_FILE=/usr/local/share/ca-certificates/ca-certificates.crt vagrant plugin install vagrant-certificates
+# vagrantfiles put in .vagrant.d will be appended to ALL vagrantfiles on this system
+	mkdir -p ~/.vagrant.d
+	cp Vagrantfile ~/.vagrant.d/Vagrantfile

--- a/install/mac/Vagrantfile
+++ b/install/mac/Vagrantfile
@@ -1,4 +1,3 @@
-# These are requirements for this base Vagrantfile. If they are not
 %w(vagrant-certificates).each do |name|
   warn "Please install the '#{name}' plugin!" unless Vagrant.has_plugin?(name)
 end

--- a/install/mac/Vagrantfile
+++ b/install/mac/Vagrantfile
@@ -1,0 +1,9 @@
+# These are requirements for this base Vagrantfile. If they are not
+%w(vagrant-certificates).each do |name|
+  warn "Please install the '#{name}' plugin!" unless Vagrant.has_plugin?(name)
+end
+
+Vagrant.configure('2') do |config|
+  config.certificates.enabled = true
+  config.certificates.certs = Dir.glob('/usr/local/share/ca-certificates/**/*.crt')
+end


### PR DESCRIPTION
## Closes/fixes/resolves issue(s)?
Closes https://github.com/fredrikhgrelland/vagrant-hashistack-template/issues/74
Closes #439 

## What was added/changed/fixed?
`make install` now handles MacOS systems behind transparent proxies. Exports all certificates from keychain to a `ca-certificates.crt`, installs the [vagrant-certificates](https://github.com/gfi-centre-ouest/vagrant-certificates) plugin, then adds a Vagrant with conf that uses the plugin to the `.vagrant.d` folder. This Vagrantfile will be appended to all other Vagrantfiles, so that they all have the handling of certificates.

## Related issue(s)? [Optional]

## Others [Optional]

## Checklist (after created PR)
- [x] Added reviewers
- [x] Added assignee(s)
- [x] Added label(s)
- [x] Added to project
- [x] Added to milestone